### PR TITLE
Fix javascript exception keyword highlighting

### DIFF
--- a/estilo/syntax/base.yml
+++ b/estilo/syntax/base.yml
@@ -54,8 +54,8 @@ Number: "" # Constant
 Float: "" # Constant
 Identifier: "keywords"
 Function: "keywords" # Identifier
-Statement: ""
-Conditional: "keywords" # Statement
+Statement: "keywords"
+Conditional: "" # Statement
 Repeat: "" # Statement
 Label: "" # Statement
 Operator: "keywords ." # Statement

--- a/estilo/syntax/javascript.yml
+++ b/estilo/syntax/javascript.yml
@@ -74,7 +74,7 @@ javaScriptBoolean: 'constants' # Boolean
 javaScriptRegexpString: 'white' # String
 javaScriptIdentifier: 'other' # Identifier
 javaScriptLabel: 'other' # Label
-javaScriptException: 'invalid' # Exception
+javaScriptException: '' # Exception
 javaScriptMessage: '' # Keyword
 javaScriptGlobal: '' # Keyword
 javaScriptMember: 'contrastLite' # Keyword


### PR DESCRIPTION
Before:
![image](https://github.com/user-attachments/assets/8ddbbd00-93c7-4a5d-b8f4-0cdc2a84c913)

After:
![image](https://github.com/user-attachments/assets/6548802b-7b49-4f85-ac37-fc870e7489d6)

VSCode:
![image](https://github.com/user-attachments/assets/86846957-ac23-46c4-8028-49f330e370e4)
