### PR TITLE
Fix javascript global identifier highlighting

### DIFF
--- a/estilo/syntax/javascript.yml
+++ b/estilo/syntax/javascript.yml
@@ -76,7 +76,7 @@ javaScriptIdentifier: 'other' # Identifier
 javaScriptLabel: 'other' # Label
 javaScriptException: 'invalid' # Exception
 javaScriptMessage: '' # Keyword
-javaScriptGlobal: '' # Keyword
+javaScriptGlobal: 'other' # Keyword
 javaScriptMember: 'contrastLite' # Keyword
 javaScriptDeprecated: '' # Exception
 javaScriptReserved: '' # Keyword


### PR DESCRIPTION
Before:
![image](https://github.com/user-attachments/assets/9734b403-7637-4775-9918-06ce3fe84ea7)

After:
![image](https://github.com/user-attachments/assets/d0651fca-7d3e-4845-8934-66f87c19cee6)

VSCode:
![image](https://github.com/user-attachments/assets/7c11d619-b6f5-4ed8-8bec-067dd6a49559)
